### PR TITLE
Fix calendar handling

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -144,10 +144,11 @@ def read_data(
 
     """
 
+    use_cftime = True if output_calendar else False
     if len(infiles) == 1:
-        ds = xr.open_dataset(infiles[0], use_cftime=True)
+        ds = xr.open_dataset(infiles[0], use_cftime=use_cftime)
     else:
-        ds = xr.open_mfdataset(infiles, use_cftime=True)
+        ds = xr.open_mfdataset(infiles, use_cftime=use_cftime)
 
     try:
         ds = ds.drop('height')


### PR DESCRIPTION
Needs to handle calendar matching for the training step (which requires `cftime`) and for QDM the adjustment step needs to handle time deltas if the `--ref_time` option is used (which requires `np.datetime64`).